### PR TITLE
Removing unnecessary doc-gen plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,18 +152,6 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.wso2.siddhi</groupId>
-                <artifactId>siddhi-doc-gen</artifactId>
-                <version>${siddhi.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate-md-docs</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
 
         <pluginManagement>


### PR DESCRIPTION
## Purpose
> siddhi-doc-gen plugin is found in component pom

## Goals
> Removing unnecessary doc-gen plugin 

## Approach
> Removing unnecessary doc-gen plugin from parent pom