### PR TITLE
Adding Geo-coordinate Stream Function

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
@@ -40,15 +40,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-
 /**
  * This class is to get longitude and latitude value of login location based on ip address.
  */
-
 @Extension(
         name = "geocoordinate",
         namespace = "geo",
-        description = "stream function",
+        description = "geocoordinate stream function returns the longitude and latitude" +
+                " values of a location which is related to the given IPV4 or IPV6 address.\"",
         parameters = {
                 @Parameter(
                         name = "ip",
@@ -78,7 +77,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 )
 
 public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcessor {
-
     private static final Log log = LogFactory.getLog(GeoCoordinateStreamFunctionProcessor.class);
     private static GeoCoordinateResolver geoCoordinateResolverImpl;
     private static final String DEFAULT_GEOCOORDINATE_RESOLVER_CLASSNAME =
@@ -182,8 +180,6 @@ public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcesso
     private void initializeExtensionConfigs(ConfigReader configReader) throws SiddhiAppValidationException {
         String geoResolverImplClassName = configReader.readConfig("geoCoordinateResolverClass",
                 DEFAULT_GEOCOORDINATE_RESOLVER_CLASSNAME);
-
-
         try {
             geoCoordinateResolverImpl = (GeoCoordinateResolver) Class.forName
                     (geoResolverImplClassName).newInstance();

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
@@ -17,8 +17,6 @@
  */
 package org.wso2.extension.siddhi.execution.geo;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinate;
 import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinateResolver;
 import org.wso2.extension.siddhi.execution.geo.internal.exception.GeoLocationResolverException;
@@ -35,7 +33,7 @@ import org.wso2.siddhi.query.api.definition.AbstractDefinition;
 import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -77,7 +75,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 )
 
 public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcessor {
-    private static final Log log = LogFactory.getLog(GeoCoordinateStreamFunctionProcessor.class);
     private static GeoCoordinateResolver geoCoordinateResolverImpl;
     private static final String DEFAULT_GEOCOORDINATE_RESOLVER_CLASSNAME =
             "org.wso2.extension.siddhi.execution.geo.internal.impl.APIBasedGeoCoordinateResolver";
@@ -127,7 +124,7 @@ public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcesso
         if (!isExtensionConfigInitialized.get()) {
             initializeExtensionConfigs(configReader);
         }
-        ArrayList<Attribute> attributes = new ArrayList<Attribute>(6);
+        List<Attribute> attributes = new ArrayList<Attribute>(6);
         attributes.add(new Attribute("latitude", Attribute.Type.DOUBLE));
         attributes.add(new Attribute("longitude", Attribute.Type.DOUBLE));
         return attributes;
@@ -162,7 +159,7 @@ public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcesso
      */
     @Override
     public Map<String, Object> currentState() {
-        return new HashMap<String, Object>();
+        return Collections.emptyMap();
     }
 
     /**

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/GeoCoordinateStreamFunctionProcessor.java
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.extension.siddhi.execution.geo;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinate;
+import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinateResolver;
+import org.wso2.extension.siddhi.execution.geo.internal.impl.APIBasedGeoCoordinateResolver;
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.annotation.Parameter;
+import org.wso2.siddhi.annotation.ReturnAttribute;
+import org.wso2.siddhi.annotation.util.DataType;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.executor.ExpressionExecutor;
+import org.wso2.siddhi.core.query.processor.stream.function.StreamFunctionProcessor;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.query.api.definition.AbstractDefinition;
+import org.wso2.siddhi.query.api.definition.Attribute;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * This class is to get longitude and latitude value of login location based on ip address.
+ */
+
+@Extension(
+        name = "geocoordinate",
+        namespace = "geo",
+        description = "stream function",
+        examples = @Example(
+                description = "This will returns the Longitude and latitude of the given login ip",
+                syntax = "geocoordinate(\"ip address\")"),
+        parameters = {
+                @Parameter(
+                        name = "ip",
+                        description = "login ip address",
+                        type = {DataType.STRING})
+        },
+        returnAttributes = {
+                @ReturnAttribute(
+                        name = "longitude",
+                        description = "Longitude of the location", type = DataType.DOUBLE
+                ),
+                @ReturnAttribute(
+                        name = "latitude",
+                        description = "Latitude of the location", type = DataType.DOUBLE
+                )
+        }
+)
+
+public class GeoCoordinateStreamFunctionProcessor extends StreamFunctionProcessor {
+
+    private static final Log log = LogFactory.getLog(GeoCoordinateStreamFunctionProcessor.class);
+    private GeoCoordinateResolver geoVelocityResolverImpl = new APIBasedGeoCoordinateResolver();
+    private String apikey;
+
+    /**
+     * The process method used when more than one function parameters are provided
+     *
+     * @param data the data values for the function parameters
+     * @return the data for additional output attributes introduced by the function
+     */
+    @Override
+    protected Object[] process(Object[] data) {
+        return new Object[0];
+    }
+
+    /**
+     * The process method used when zero or one function parameter is provided
+     *
+     * @param data null if the function parameter count is zero or runtime data value of the function parameter
+     * @return the data for additional output attribute introduced by the function
+     */
+    @Override
+    protected Object[] process(Object data) {
+        GeoCoordinate geoCoordinate;
+        String ip = data.toString();
+        geoCoordinate = geoVelocityResolverImpl.getGeoCoordinateInfo(apikey, ip);
+        return new Object[]{geoCoordinate.getLatitude(), geoCoordinate.getLongitude()};
+    }
+
+    /**
+     * The initialization method for {@link StreamFunctionProcessor},
+     * which will be called before other methods and validate
+     * the all configuration and getting the initial values.
+     *
+     * @param inputDefinition              the incoming stream definition
+     * @param attributeExpressionExecutors the executors of each function parameters
+     * @param configReader                 this hold the {@link StreamFunctionProcessor} extensions
+     *                                     configuration reader.
+     * @param siddhiAppContext             the context of the siddhi app
+     * @return the output's additional attributes list introduced by the function
+     */
+    @Override
+    protected List<Attribute> init(AbstractDefinition inputDefinition,
+                                   ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader,
+                                   SiddhiAppContext siddhiAppContext) {
+        configReader.getAllConfigs().forEach((key, value) -> {
+            apikey = value;
+        });
+        ArrayList<Attribute> attributes = new ArrayList<Attribute>(6);
+        attributes.add(new Attribute("latitude", Attribute.Type.DOUBLE));
+        attributes.add(new Attribute("longitude", Attribute.Type.DOUBLE));
+        return attributes;
+    }
+
+    /**
+     * This will be called only once and this can be used to acquire
+     * required resources for the processing element.
+     * This will be called after initializing the system and before
+     * starting to process the events.
+     */
+    @Override
+    public void start() {
+
+    }
+
+    /**
+     * This will be called only once and this can be used to release
+     * the acquired resources for processing.
+     * This will be called before shutting down the system.
+     */
+    @Override
+    public void stop() {
+
+    }
+
+    /**
+     * Used to collect the serializable state of the processing element, that need to be
+     * persisted for reconstructing the element to the same state on a different point of time
+     *
+     * @return stateful objects of the processing element as an map
+     */
+    @Override
+    public Map<String, Object> currentState() {
+        return new HashMap<String, Object>();
+    }
+
+    /**
+     * Used to restore serialized state of the processing element, for reconstructing
+     * the element to the same state as if was on a previous point of time.
+     *
+     * @param state the stateful objects of the processing element as a map.
+     *              This is the same map that is created upon calling currentState() method.
+     */
+    @Override
+    public void restoreState(Map<String, Object> state) {
+
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinate.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinate.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.extension.siddhi.execution.geo.api;
+
+/**
+ * This is the bean class which represents the GeoCoordinate.
+ */
+public class GeoCoordinate {
+    private final double latitude;
+    private final double longitude;
+
+    public GeoCoordinate(double latitude, double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.extension.siddhi.execution.geo.api;
+
+import org.wso2.extension.siddhi.execution.geo.internal.exception.GeoLocationResolverException;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+
+/**
+ * Interface for the GeoCoordinates based on the ip address.
+ */
+public interface GeoCoordinateResolver {
+    /**
+     * This method will provide the geo location information related to the given ip.
+     *
+     * @param key key
+     * @param ip ip address
+     * @return geo coordinate information related to given ip address
+     */
+
+    public GeoCoordinate getGeoCoordinateInfo(String key, String ip);
+
+    /**
+     * This method will be invoked after the initializing the extension. You can do any initial configuration here.
+     *
+     * @param configReader
+     * @throws GeoLocationResolverException
+     */
+    public void init(ConfigReader configReader) throws GeoLocationResolverException;
+
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
@@ -28,12 +28,11 @@ public interface GeoCoordinateResolver {
     /**
      * This method will provide the geo location information related to the given ip.
      *
-     * @param key key
      * @param ip ip address
      * @return geo coordinate information related to given ip address
      */
 
-    public GeoCoordinate getGeoCoordinateInfo(String key, String ip);
+    public GeoCoordinate getGeoCoordinateInfo(String ip);
 
     /**
      * This method will be invoked after the initializing the extension. You can do any initial configuration here.

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/api/GeoCoordinateResolver.java
@@ -25,13 +25,13 @@ import org.wso2.siddhi.core.util.config.ConfigReader;
  * Interface for the GeoCoordinates based on the ip address.
  */
 public interface GeoCoordinateResolver {
+
     /**
      * This method will provide the geo location information related to the given ip.
      *
      * @param ip ip address
      * @return geo coordinate information related to given ip address
      */
-
     public GeoCoordinate getGeoCoordinateInfo(String ip);
 
     /**

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.extension.siddhi.execution.geo.internal.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinate;
+import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinateResolver;
+import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The default implementation of the GeoCoordinateResolver interface. This is implemented is based on API.
+ */
+public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
+    private static final Log log = LogFactory.getLog(APIBasedGeoCoordinateResolver.class);
+    private String temporary = null;
+
+    @Override
+    public void init(ConfigReader configReader) {
+    }
+
+    @Override
+    public GeoCoordinate getGeoCoordinateInfo(String key, String ip) {
+        double latitude;
+        double longitude;
+        ip = ip.trim();
+        if (ip.contains(",")) {
+            String locationDetails[] = ip.split(",");
+            ip = locationDetails[1].trim();
+        }
+        URL url;
+        try {
+            url = new URL(key + ip);
+        } catch (MalformedURLException e) {
+            throw new SiddhiAppRuntimeException ("Error", e);
+        }
+        try (
+                InputStreamReader inputStreamReader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
+                BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
+
+            String strTemp = null;
+            String locationDetails[] = null;
+            while (null != (strTemp = bufferedReader.readLine())) {
+                temporary = strTemp;
+            }
+            locationDetails = temporary.split(";");
+            latitude = Double.parseDouble(locationDetails[8]);
+            longitude = Double.parseDouble(locationDetails[9]);
+        } catch (IOException e) {
+            throw new SiddhiAppRuntimeException("Error", e);
+        }
+        return new GeoCoordinate(latitude, longitude);
+    }
+}

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
@@ -29,10 +29,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 /**
- * The default implementation of the GeoCoordinateResolver interface. This is implemented is based on API.
+ * The default implementation of the GeoCoordinateResolver interface. This implementation is based on API.
  */
 public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
-    private String temporary = null;
+    private String ipInformation = null;
     private String apikey;
 
     @Override
@@ -45,10 +45,6 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
         double latitude;
         double longitude;
         ip = ip.trim();
-        if (ip.contains(",")) {
-            String locationDetails[] = ip.split(",");
-            ip = locationDetails[1].trim();
-        }
         URL url;
         try {
             url = new URL(apikey + ip);
@@ -59,12 +55,12 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
         try (
                 InputStreamReader inputStreamReader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
                 BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-            String strTemp = null;
-            String locationDetails[] = null;
-            while (null != (strTemp = bufferedReader.readLine())) {
-                temporary = strTemp;
+            String ipData;
+            String locationDetails[];
+            while (null != (ipData = bufferedReader.readLine())) {
+                ipInformation = ipData;
             }
-            locationDetails = temporary.split(";");
+            locationDetails = ipInformation.split(";");
             latitude = Double.parseDouble(locationDetails[8]);
             longitude = Double.parseDouble(locationDetails[9]);
         } catch (IOException e) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
@@ -17,8 +17,6 @@
  */
 package org.wso2.extension.siddhi.execution.geo.internal.impl;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinate;
 import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinateResolver;
 import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
@@ -34,7 +32,6 @@ import java.nio.charset.StandardCharsets;
  * The default implementation of the GeoCoordinateResolver interface. This is implemented is based on API.
  */
 public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
-    private static final Log log = LogFactory.getLog(APIBasedGeoCoordinateResolver.class);
     private String temporary = null;
     private String apikey;
 
@@ -56,7 +53,8 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
         try {
             url = new URL(apikey + ip);
         } catch (MalformedURLException e) {
-            throw new SiddhiAppRuntimeException ("Error in connection to the API", e);
+            throw new SiddhiAppRuntimeException ("Error in connection to the API " +
+                    "with the given key value of the API", e);
         }
         try (
                 InputStreamReader inputStreamReader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
@@ -70,7 +68,8 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
             latitude = Double.parseDouble(locationDetails[8]);
             longitude = Double.parseDouble(locationDetails[9]);
         } catch (IOException e) {
-            throw new SiddhiAppRuntimeException("Error in connection to the API", e);
+            throw new SiddhiAppRuntimeException("Cannot retrieve longitute and latitude " +
+                    "due to error in connection to the API", e);
         }
         return new GeoCoordinate(latitude, longitude);
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
@@ -37,13 +37,15 @@ import java.nio.charset.StandardCharsets;
 public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
     private static final Log log = LogFactory.getLog(APIBasedGeoCoordinateResolver.class);
     private String temporary = null;
+    private String apikey;
 
     @Override
     public void init(ConfigReader configReader) {
+        apikey = configReader.getAllConfigs().get("key");
     }
 
     @Override
-    public GeoCoordinate getGeoCoordinateInfo(String key, String ip) {
+    public GeoCoordinate getGeoCoordinateInfo(String ip) {
         double latitude;
         double longitude;
         ip = ip.trim();
@@ -53,9 +55,9 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
         }
         URL url;
         try {
-            url = new URL(key + ip);
+            url = new URL(apikey + ip);
         } catch (MalformedURLException e) {
-            throw new SiddhiAppRuntimeException ("Error", e);
+            throw new SiddhiAppRuntimeException ("Error in connection to the API", e);
         }
         try (
                 InputStreamReader inputStreamReader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
@@ -70,7 +72,7 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
             latitude = Double.parseDouble(locationDetails[8]);
             longitude = Double.parseDouble(locationDetails[9]);
         } catch (IOException e) {
-            throw new SiddhiAppRuntimeException("Error", e);
+            throw new SiddhiAppRuntimeException("Error in connection to the API", e);
         }
         return new GeoCoordinate(latitude, longitude);
     }

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/geo/internal/impl/APIBasedGeoCoordinateResolver.java
@@ -23,7 +23,6 @@ import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinate;
 import org.wso2.extension.siddhi.execution.geo.api.GeoCoordinateResolver;
 import org.wso2.siddhi.core.exception.SiddhiAppRuntimeException;
 import org.wso2.siddhi.core.util.config.ConfigReader;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -62,7 +61,6 @@ public class APIBasedGeoCoordinateResolver implements GeoCoordinateResolver {
         try (
                 InputStreamReader inputStreamReader = new InputStreamReader(url.openStream(), StandardCharsets.UTF_8);
                 BufferedReader bufferedReader = new BufferedReader(inputStreamReader)) {
-
             String strTemp = null;
             String locationDetails[] = null;
             while (null != (strTemp = bufferedReader.readLine())) {

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.5</version>
+                    <version>3.5.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <obrRepository>NONE</obrRepository>


### PR DESCRIPTION
## Purpose
Add GeoCoordinate stream function to get longitude and latitude values of a given ip address

## Goals
Get longitude and latitude values of given ipv4 or ipv6 address by this added GeoCoordinate stream function.

## Documentation
Please find the additional information related to this feature.

This feature enables to retrieve the latitude and longitude values based on the given IPV4 or IPV6 address. Users can use the extension as follows and provide the IP address. Then it will process the given IP address and retrieve the latitude and longitude values based on the extension function.
```sh
define stream IpStream(ip string); from IpStream#geo:geocoordinate(ip) select longitude, latitude insert into outputStream;
```
Moreover, users can extend the "GeoCoordinateResolver" interface and do their own implementation. After that they can put that own implementation bundle in SP_HOME/lib directory and configure the deployment.yaml as follows,

```sh
siddhi:
  extensions:
    -
      extension:
        name: geocoordinate
        namespace: geo
        properties:
          key: [value]
```
