### PR TITLE
Update mkdocs configs that cause build failure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,8 +27,10 @@ extra:
     link: https://www.linkedin.com/groups/13553064
 markdown_extensions:
 - admonition
-- toc(permalink=true)
-- codehilite(guess_lang=false)
+- toc:
+    permalink: true
+- codehilite:
+    guess_lang: false
 pages:
 - Welcome: index.md
 - API Docs:


### PR DESCRIPTION
## Purpose
> Preventing build failure [1] when generating docs. 

[1] https://wso2.org/jenkins/view/All%20Builds/job/siddhi/job/siddhi-execution-geo/189/console
```
[INFO] [WARNING] Failed to deploy the documentation on github pages.
[INFO] java.io.FileNotFoundException: Source 'site' does not exist
```

## Learning
> - https://github.com/mkdocs/mkdocs/issues/1640#issuecomment-424799608
> - https://github.com/squidfunk/mkdocs-material/blob/master/docs/getting-started.md#extensions